### PR TITLE
Handle projects with RootNamespace empty

### DIFF
--- a/VocaDb.ResXFileCodeGenerator.Tests/GeneratorTests.cs
+++ b/VocaDb.ResXFileCodeGenerator.Tests/GeneratorTests.cs
@@ -584,7 +584,7 @@ public static class CommonMessages
 	[Fact]
 	public void GetLocalNamespace_ShouldNotGenerateIllegalNamespace()
 	{
-		var ns = Utilities.GetLocalNamespace("resx", "asd.asd", "path", "root");
+		var ns = Utilities.GetLocalNamespace("resx", "asd.asd", "path", "name", "root");
 		ns.Should().Be("root");
 	}
 

--- a/VocaDb.ResXFileCodeGenerator.Tests/SettingsTests.cs
+++ b/VocaDb.ResXFileCodeGenerator.Tests/SettingsTests.cs
@@ -12,8 +12,9 @@ public class SettingsTests
 		provider: new AnalyzerConfigOptionsProviderStub(
 			globalOptions: new AnalyzerConfigOptionsStub
 			{
-				RootNamespace = "required1",
-				MSBuildProjectFullPath = "required2"
+				RootNamespace = "namespace1",
+				MSBuildProjectFullPath = "project1.csproj",
+				MSBuildProjectName = "project1",
 			},
 			fileOptions: null!
 		),
@@ -24,8 +25,9 @@ public class SettingsTests
 	public void GlobalDefaults()
 	{
 		var globalOptions = s_globalOptions;
-		globalOptions.RootNamespace.Should().Be("required1");
-		globalOptions.ProjectFullPath.Should().Be("required2");
+		globalOptions.ProjectName.Should().Be("project1");
+		globalOptions.RootNamespace.Should().Be("namespace1");
+		globalOptions.ProjectFullPath.Should().Be("project1.csproj");
 		globalOptions.InnerClassName.Should().BeNullOrEmpty();
 		globalOptions.ClassNamePostfix.Should().BeNullOrEmpty();
 		globalOptions.InnerClassInstanceName.Should().BeNullOrEmpty();
@@ -45,7 +47,9 @@ public class SettingsTests
 			provider: new AnalyzerConfigOptionsProviderStub(
 				globalOptions: new AnalyzerConfigOptionsStub
 				{
-					RootNamespace = "required1", MSBuildProjectFullPath = "required2",
+					RootNamespace = "namespace1",
+					MSBuildProjectFullPath = "project1.csproj",
+					MSBuildProjectName = "project1",
 					ResXFileCodeGenerator_InnerClassName = "test1",
 					ResXFileCodeGenerator_InnerClassInstanceName = "test2",
 					ResXFileCodeGenerator_ClassNamePostfix= "test3",
@@ -61,8 +65,9 @@ public class SettingsTests
 			),
 			token: default
 		);
-		globalOptions.RootNamespace.Should().Be("required1");
-		globalOptions.ProjectFullPath.Should().Be("required2");
+		globalOptions.RootNamespace.Should().Be("namespace1");
+		globalOptions.ProjectFullPath.Should().Be("project1.csproj");
+		globalOptions.ProjectName.Should().Be("project1");
 		globalOptions.InnerClassName.Should().Be("test1");
 		globalOptions.InnerClassInstanceName.Should().Be("test2");
 		globalOptions.ClassNamePostfix.Should().Be("test3");
@@ -100,9 +105,64 @@ public class SettingsTests
 		fileOptions.PublicClass.Should().Be(false);
 		fileOptions.PartialClass.Should().Be(false);
 		fileOptions.UseVocaDbResManager.Should().Be(false);
-		fileOptions.LocalNamespace.Should().Be("required1");
+		fileOptions.LocalNamespace.Should().Be("namespace1");
 		fileOptions.CustomToolNamespace.Should().BeNullOrEmpty();
 		fileOptions.File.Path.Should().Be("Path1.resx");
+		fileOptions.ClassName.Should().Be("Path1");
+		fileOptions.IsValid.Should().Be(true);
+	}
+
+	[Theory]
+	[InlineData("project1.csproj", "Path1.resx", null, "project1", "Path1")]
+	[InlineData("project1.csproj", "Path1.resx", "", "project1", "Path1")]
+	[InlineData("project1.csproj", "Path1.resx", "rootNamespace","rootNamespace", "rootNamespace.Path1")]
+	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder\Path1.resx", "rootNamespace", "rootNamespace.SubFolder", "rootNamespace.SubFolder.Path1")]
+	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder With Space\Path1.resx", "rootNamespace", "rootNamespace.SubFolder_With_Space", "rootNamespace.SubFolder_With_Space.Path1")]
+	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder\Path1.resx", null, "SubFolder", "SubFolder.Path1")]
+	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\Path1.resx", null, "_8_project", "Path1")]
+	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\SubFolder\Path1.resx", null, "SubFolder", "SubFolder.Path1")]
+	public void FileSettings_RespectsEmptyRootNamespace(string msBuildProjectFullPath,
+		string mainFile,
+		string rootNamespace,
+		string expectedLocalNamespace,
+		string expectedEmbeddedFilename)
+	{
+		var fileOptions = FileOptions.Select(
+			file: new(
+				mainFile: new AdditionalTextStub(mainFile),
+				subFiles: Array.Empty<AdditionalText>()
+			),
+			options: new AnalyzerConfigOptionsProviderStub(
+				globalOptions: null!,
+				fileOptions: new AnalyzerConfigOptionsStub()
+			),
+			globalOptions: GlobalOptions.Select(
+				provider: new AnalyzerConfigOptionsProviderStub(
+					globalOptions: new AnalyzerConfigOptionsStub
+					{
+						MSBuildProjectName = Path.GetFileNameWithoutExtension(msBuildProjectFullPath),
+						RootNamespace = rootNamespace,
+						MSBuildProjectFullPath = msBuildProjectFullPath
+					},
+					fileOptions: null!
+				),
+				token: default
+			),
+			token: default
+		);
+		fileOptions.InnerClassName.Should().BeNullOrEmpty();
+		fileOptions.InnerClassInstanceName.Should().BeNullOrEmpty();
+		fileOptions.InnerClassVisibility.Should().Be(InnerClassVisibility.NotGenerated);
+		fileOptions.NullForgivingOperators.Should().Be(false);
+		fileOptions.StaticClass.Should().Be(true);
+		fileOptions.StaticMembers.Should().Be(true);
+		fileOptions.PublicClass.Should().Be(false);
+		fileOptions.PartialClass.Should().Be(false);
+		fileOptions.UseVocaDbResManager.Should().Be(false);
+		fileOptions.LocalNamespace.Should().Be(expectedLocalNamespace);
+		fileOptions.CustomToolNamespace.Should().BeNullOrEmpty();
+		fileOptions.File.Path.Should().Be(mainFile);
+		fileOptions.EmbeddedFilename.Should().Be(expectedEmbeddedFilename);
 		fileOptions.ClassName.Should().Be("Path1");
 		fileOptions.IsValid.Should().Be(true);
 	}
@@ -138,7 +198,7 @@ public class SettingsTests
 				globalOptions: null!,
 				fileOptions: new AnalyzerConfigOptionsStub
 				{
-					RootNamespace = "required1", MSBuildProjectFullPath = "required2",
+					RootNamespace = "namespace1", MSBuildProjectFullPath = "project1.csproj",
 					CustomToolNamespace = "ns1",
 					InnerClassName = "test1",
 					InnerClassInstanceName = "test2",
@@ -164,7 +224,7 @@ public class SettingsTests
 		fileOptions.PartialClass.Should().Be(true);
 		fileOptions.IsValid.Should().Be(true);
 		fileOptions.UseVocaDbResManager.Should().Be(true);
-		fileOptions.LocalNamespace.Should().Be("required1");
+		fileOptions.LocalNamespace.Should().Be("namespace1");
 		fileOptions.CustomToolNamespace.Should().Be("ns1");
 		fileOptions.File.Path.Should().Be("Path1.resx");
 		fileOptions.ClassName.Should().Be("Path1");
@@ -177,8 +237,9 @@ public class SettingsTests
 			provider: new AnalyzerConfigOptionsProviderStub(
 				globalOptions: new AnalyzerConfigOptionsStub
 				{
-					RootNamespace = "required1",
-					MSBuildProjectFullPath = "required2",
+					RootNamespace = "namespace1",
+					MSBuildProjectFullPath = "project1.csproj",
+					MSBuildProjectName = "project1",
 					ResXFileCodeGenerator_InnerClassName = "test1",
 					ResXFileCodeGenerator_InnerClassInstanceName = "test2",
 					ResXFileCodeGenerator_ClassNamePostfix= "test3",
@@ -215,7 +276,7 @@ public class SettingsTests
 		fileOptions.PartialClass.Should().Be(true);
 		fileOptions.IsValid.Should().Be(true);
 		fileOptions.UseVocaDbResManager.Should().Be(false);
-		fileOptions.LocalNamespace.Should().Be("required1");
+		fileOptions.LocalNamespace.Should().Be("namespace1");
 		fileOptions.CustomToolNamespace.Should().BeNullOrEmpty();
 		fileOptions.File.Path.Should().Be("Path1.resx");
 		fileOptions.ClassName.Should().Be("Path1test3");
@@ -226,6 +287,8 @@ public class SettingsTests
 	{
 		// ReSharper disable InconsistentNaming
 		public string? MSBuildProjectFullPath { get; init; }
+		// ReSharper disable InconsistentNaming
+		public string? MSBuildProjectName { get; init; }
 		public string? RootNamespace { get; init; }
 		public string? ResXFileCodeGenerator_ClassNamePostfix { get; init; }
 		public string? ResXFileCodeGenerator_PublicClass { get; init; }
@@ -258,6 +321,7 @@ public class SettingsTests
 				key switch
 				{
 					"build_property.MSBuildProjectFullPath" => MSBuildProjectFullPath,
+					"build_property.MSBuildProjectName" => MSBuildProjectName,
 					"build_property.RootNamespace" => RootNamespace,
 					"build_property.ResXFileCodeGenerator_UseVocaDbResManager" => ResXFileCodeGenerator_UseVocaDbResManager,
 					"build_property.ResXFileCodeGenerator_ClassNamePostfix" => ResXFileCodeGenerator_ClassNamePostfix,

--- a/VocaDb.ResXFileCodeGenerator.Tests/SettingsTests.cs
+++ b/VocaDb.ResXFileCodeGenerator.Tests/SettingsTests.cs
@@ -113,14 +113,16 @@ public class SettingsTests
 	}
 
 	[Theory]
-	[InlineData("project1.csproj", "Path1.resx", null, "project1", "Path1")]
-	[InlineData("project1.csproj", "Path1.resx", "", "project1", "Path1")]
+	[InlineData("project1.csproj", "Path1.resx", null, "project1", "project1.Path1")]
+	[InlineData("project1.csproj", "Path1.resx", "", "project1", "project1.Path1")]
 	[InlineData("project1.csproj", "Path1.resx", "rootNamespace","rootNamespace", "rootNamespace.Path1")]
 	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder\Path1.resx", "rootNamespace", "rootNamespace.SubFolder", "rootNamespace.SubFolder.Path1")]
 	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder With Space\Path1.resx", "rootNamespace", "rootNamespace.SubFolder_With_Space", "rootNamespace.SubFolder_With_Space.Path1")]
 	[InlineData(@"ProjectFolder\project1.csproj", @"ProjectFolder\SubFolder\Path1.resx", null, "SubFolder", "SubFolder.Path1")]
-	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\Path1.resx", null, "_8_project", "Path1")]
+	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\Path1.resx", null, "_8_project", "_8_project.Path1")]
+	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\Path1.resx", "", "_8_project", "_8_project.Path1")]
 	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\SubFolder\Path1.resx", null, "SubFolder", "SubFolder.Path1")]
+	[InlineData(@"ProjectFolder\8 project.csproj", @"ProjectFolder\SubFolder\Path1.resx", "", "SubFolder", "SubFolder.Path1")]
 	public void FileSettings_RespectsEmptyRootNamespace(string msBuildProjectFullPath,
 		string mainFile,
 		string rootNamespace,

--- a/VocaDb.ResXFileCodeGenerator.Tests/UtilitiesTests.cs
+++ b/VocaDb.ResXFileCodeGenerator.Tests/UtilitiesTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace VocaDb.ResXFileCodeGenerator.Tests;
+
+public class UtilitiesTests
+{
+ 
+
+	[Theory]
+	[InlineData("Valid", "Valid")]
+	[InlineData("_Valid", "_Valid")]
+	[InlineData("Valid123", "Valid123")]
+	[InlineData("Valid_123", "Valid_123")]
+	[InlineData("Valid.123", "Valid.123")]
+	[InlineData("8Ns", "_8Ns")]
+	[InlineData("Ns+InvalidChar", "Ns_InvalidChar")]
+	[InlineData("Ns..Folder...Folder2", "Ns.Folder.Folder2")]
+	[InlineData("Ns.Folder.", "Ns.Folder")]
+	[InlineData(".Ns.Folder", "Ns.Folder")]
+	[InlineData("Folder with space", "Folder_with_space")]
+	[InlineData("folder with .. space", "folder_with_._space")]
+	public void SanitizeNamespace(string input, string expected)
+	{
+		Utilities.SanitizeNamespace(input).Should().Be(expected);
+	}
+
+	[Theory]
+	[InlineData("Valid", "Valid")]
+	[InlineData(".Valid", ".Valid")]
+	[InlineData("8Ns", "8Ns")]
+	[InlineData("..Ns", ".Ns")]
+	public void SanitizeNamespaceWithoutFirstCharRules(string input, string expected)
+	{
+		Utilities.SanitizeNamespace(input, false).Should().Be(expected);
+	}
+
+}

--- a/VocaDb.ResXFileCodeGenerator/FileOptions.cs
+++ b/VocaDb.ResXFileCodeGenerator/FileOptions.cs
@@ -57,6 +57,7 @@ public sealed record FileOptions // this must be a record or implement IEquatabl
 				? link
 				: null,
 			globalOptions.ProjectFullPath,
+			globalOptions.ProjectName,
 			globalOptions.RootNamespace);
 		 
 		EmbeddedFilename = string.IsNullOrEmpty(detectedNamespace) ? classNameFromFileName : $"{detectedNamespace}.{classNameFromFileName}";
@@ -67,6 +68,7 @@ public sealed record FileOptions // this must be a record or implement IEquatabl
 				? Utilities.GetLocalNamespace(
 					resxFilePath, targetPath,
 					globalOptions.ProjectFullPath,
+					globalOptions.ProjectName,
 					globalOptions.RootNamespace)
 				: string.IsNullOrEmpty(detectedNamespace)
 					? Utilities.SanitizeNamespace(globalOptions.ProjectName)

--- a/VocaDb.ResXFileCodeGenerator/FileOptions.cs
+++ b/VocaDb.ResXFileCodeGenerator/FileOptions.cs
@@ -58,7 +58,8 @@ public sealed record FileOptions // this must be a record or implement IEquatabl
 				: null,
 			globalOptions.ProjectFullPath,
 			globalOptions.RootNamespace);
-		EmbeddedFilename = detectedNamespace + "." + classNameFromFileName;
+		 
+		EmbeddedFilename = string.IsNullOrEmpty(detectedNamespace) ? classNameFromFileName : $"{detectedNamespace}.{classNameFromFileName}";
 
 		LocalNamespace =
 			options.TryGetValue("build_metadata.EmbeddedResource.TargetPath", out var targetPath) &&
@@ -67,7 +68,9 @@ public sealed record FileOptions // this must be a record or implement IEquatabl
 					resxFilePath, targetPath,
 					globalOptions.ProjectFullPath,
 					globalOptions.RootNamespace)
-				: detectedNamespace;
+				: string.IsNullOrEmpty(detectedNamespace)
+					? Utilities.SanitizeNamespace(globalOptions.ProjectName)
+					: detectedNamespace;
 
 		CustomToolNamespace =
 			options.TryGetValue("build_metadata.EmbeddedResource.CustomToolNamespace", out var customToolNamespace) &&

--- a/VocaDb.ResXFileCodeGenerator/GlobalOptions.cs
+++ b/VocaDb.ResXFileCodeGenerator/GlobalOptions.cs
@@ -11,6 +11,7 @@ public sealed record GlobalOptions // this must be a record or implement IEquata
 	public bool PartialClass { get; }
 	public string RootNamespace { get; }
 	public string ProjectFullPath { get; }
+	public string ProjectName { get; }
 	public bool StaticClass { get; }
 	public bool NullForgivingOperators { get; }
 	public bool PublicClass { get; }
@@ -26,14 +27,19 @@ public sealed record GlobalOptions // this must be a record or implement IEquata
 		{
 			IsValid = false;
 		}
-
 		ProjectFullPath = projectFullPath!;
-		if (!options.TryGetValue("build_property.RootNamespace", out var rootNamespace))
+
+		if (options.TryGetValue("build_property.RootNamespace", out var rootNamespace))
+		{
+			RootNamespace = rootNamespace;
+		}
+		
+		if (!options.TryGetValue("build_property.MSBuildProjectName", out var projectName))
 		{
 			IsValid = false;
 		}
+		ProjectName = projectName!;
 
-		RootNamespace = rootNamespace!;
 		// Code from: https://github.com/dotnet/roslyn/blob/main/docs/features/source-generators.cookbook.md#consume-msbuild-properties-and-metadata
 		PublicClass =
 			options.TryGetValue("build_property.ResXFileCodeGenerator_PublicClass", out var publicClassSwitch) &&

--- a/VocaDb.ResXFileCodeGenerator/build/VocaDb.ResXFileCodeGenerator.props
+++ b/VocaDb.ResXFileCodeGenerator/build/VocaDb.ResXFileCodeGenerator.props
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="MSBuildProjectFullPath" />
+    <CompilerVisibleProperty Include="MSBuildProjectName" />
     <CompilerVisibleProperty Include="RootNamespace" />
     <CompilerVisibleProperty Include="CustomToolNamespace" />
     <CompilerVisibleProperty Include="ResXFileCodeGenerator_PublicClass" />


### PR DESCRIPTION
For projects with RootNamespace empty, it should not append it to embedded file name and/or the local namespace.
In case there is no root namespace, but there are subfolders, use normal sub folder to namespace
in case there is no root namespace, and the resx file is directly under project root, use project name as namespace (same behavior as Visual Studio).